### PR TITLE
Python x64 and python3 fixes

### DIFF
--- a/python/riffa.py
+++ b/python/riffa.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------
-# Copyright (c) 2015, The Regents of the University of California All
+# Copyright (c) 2016, The Regents of the University of California All
 # rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without

--- a/python/riffa.py
+++ b/python/riffa.py
@@ -1,5 +1,5 @@
 # ----------------------------------------------------------------------
-# Copyright (c) 2016, The Regents of the University of California All
+# Copyright (c) 2015, The Regents of the University of California All
 # rights reserved.
 # 
 # Redistribution and use in source and binary forms, with or without
@@ -47,6 +47,9 @@ if platform.system() == "Linux":
 	libriffa = ctypes.CDLL("libriffa.so.1")
 else:
 	libriffa = ctypes.CDLL("riffa.dll")
+
+libriffa.fpga_recv.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p, ctypes.c_int, ctypes.c_longlong]
+libriffa.fpga_send.argtypes = [ctypes.c_void_p, ctypes.c_int, ctypes.c_void_p, ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_longlong]
 
 class FpgaInfoList(ctypes.Structure):
 	_fields_ = [("num_fpgas", ctypes.c_int),
@@ -156,7 +159,7 @@ def fpga_recv(fd, chnl, data, timeout):
 			ctypes.pythonapi.PyObject_AsReadBuffer(obj, ctypes.byref(a), ctypes.byref(l))
 			ptr = a.value
 			datalen = l.value
-	return libriffa.fpga_recv(fd, chnl, ptr, datalen/4, timeout)
+	return libriffa.fpga_recv(fd, chnl, ptr, datalen//4, timeout)
 
 
 # Resets the state of the FPGA and all transfers across all channels. This is


### PR DESCRIPTION
Added type signatures to properly pass (64 bit) pointers for *data.  Send/recv was failing in driver when a truncated address was passed.  This probably could affect any 64 bit system depending on where memory was allocated, though only saw it on x64 Ubuntu 14.04.

Not sure about passing *fpga, but set it to a pointer anyway.

Changed to truncating division to support python 3. Normal Division in python 3 returns a float which could cause problems.