### PR TITLE
Jerry Hicks

### DIFF
--- a/driver/linux/Kbuild
+++ b/driver/linux/Kbuild
@@ -1,0 +1,14 @@
+# Kbuild file for riffa driver
+
+NAME        ?= riffa
+MAJOR_NUM   ?= 100
+VENDOR_ID0  ?= 10EE
+VENDOR_ID1  ?= 1172
+
+ccflags-y := -DMAJOR_NUM=$(MAJOR_NUM) \
+             -DDEVICE_NAME='"$(NAME)"' \
+             -DVENDOR_ID0=0x$(VENDOR_ID0) \
+             -DVENDOR_ID1=0x$(VENDOR_ID1)
+
+obj-m := $(NAME).o
+$(NAME)-y := riffa_driver.o circ_queue.o

--- a/driver/linux/Makefile
+++ b/driver/linux/Makefile
@@ -43,14 +43,14 @@
 # like, but make sure they will work in your system.
 # The VENDOR_ID _must_ match what is configured on your FPGA's PCIe endpoint 
 # header. Xilinx has a VENDOR_ID = 10EE.
-NAME := riffa
-VENDOR_ID0 := 10EE
-VENDOR_ID1 := 1172
-MAJNUM := 100
+NAME ?= riffa
+VENDOR_ID0 ?= 10EE
+VENDOR_ID1 ?= 1172
+MAJNUM ?= 100
 
 # Build variables
-KVER := $(shell uname -r)
-KDIR := /lib/modules/`uname -r`/build
+KVER ?= $(shell uname -r)
+KDIR ?= /lib/modules/`uname -r`/build
 RHR := /etc/redhat-release
 LIB_SRCS := riffa.c
 LIB_OBJS := $(patsubst %.c,%.o,$(LIB_SRCS))
@@ -61,8 +61,7 @@ LIB_VER := $(LIB_VER_MAJ).$(LIB_VER_MIN)
 DRVR_HDR := riffa_driver.h
 DBUGVAL := DBUG
 
-obj-m += $(NAME).o
-$(NAME)-y := riffa_driver.o circ_queue.o
+CC=$(CROSS_COMPILE)cc
 
 # Helper functions
 define assert
@@ -88,17 +87,15 @@ all: builddvr
 debug: CC += -DDEBUG -g
 debug: DBUGVAL = DEBUG
 debug: builddvr
+$(NAME).so.$(LIB_VER): CC += -DDEVICE_NAME='"$(NAME)"' \
+                             -DMAJOR_NUM=$(MAJNUM) \
+                             -DVENDOR_ID0=0x$(VENDOR_ID0) \
+                             -DVENDOR_ID1=0x$(VENDOR_ID1)
 builddvr: $(NAME).ko $(NAME).so.$(LIB_VER)
 
 $(NAME).ko: *.c *.h
 	$(call assert-variables)
-	sed -i 's/#define MAJOR_NUM [^\n]*/#define MAJOR_NUM $(MAJNUM)/g' $(DRVR_HDR)
-	sed -i 's/#define DEVICE_NAME [^\n]*/#define DEVICE_NAME "$(NAME)"/g' $(DRVR_HDR)
-	sed -i 's/#define VENDOR_ID0 [^\n]*/#define VENDOR_ID0 0x$(VENDOR_ID0)/g' $(DRVR_HDR)
-	sed -i 's/#define VENDOR_ID1 [^\n]*/#define VENDOR_ID1 0x$(VENDOR_ID1)/g' $(DRVR_HDR)
-	sed -i 's/#define DEBUG [^\n]*/#define DBUG 1/g' $(DRVR_HDR)
-	sed -i 's/#define DBUG [^\n]*/#define $(DBUGVAL) 1/g' $(DRVR_HDR)
-	make -C $(KDIR) SUBDIRS=`pwd` modules
+	make -C $(KDIR) M=$(PWD)
 	rm -rf $(LIB_OBJS)
 
 $(NAME).so.$(LIB_VER): $(LIB_OBJS)
@@ -109,7 +106,7 @@ $(LIB_OBJS): $(LIB_SRCS)
 
 load: $(NAME).ko
 	insmod $(NAME).ko
-	
+
 unload:
 	rmmod $(NAME)
 

--- a/driver/linux/riffa_driver.h
+++ b/driver/linux/riffa_driver.h
@@ -58,10 +58,21 @@
 
 // The major device number. We can't rely on dynamic registration because ioctls
 // need to know it.
+#ifndef MAJOR_NUM
 #define MAJOR_NUM 100
+#endif
+
+#ifndef DEVICE_NAME
 #define DEVICE_NAME "riffa"
+#endif
+
+#ifndef VENDOR_ID0
 #define VENDOR_ID0 0x10EE
+#endif
+
+#ifndef VENDOR_ID1
 #define VENDOR_ID1 0x1172
+#endif
 
 // Message events for readmsgs/writemsgs queues.
 #define EVENT_TXN_LEN				1


### PR DESCRIPTION
Trying to make cross-compiling for our Linux Cortex-A9 ARM a bit easier.    Please review.

I think it might be better to create the riffa_driver.h file from a riffa_driver.h.in template (as opposed to in-place sed edits).  In these mods I made it all work using conditionals but did not consider if that broke anything out of the driver subdirectory. 

We like builds that can run out-of-tree so the sources can remain immutable and compile outputs can land in a different directory   (on a read-only share, etc) but that's really only a small matter of personal taste.

Thanks for RIFFA!  We are really having a blast with it.